### PR TITLE
Create dynamic Regal-style ticket generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,87 +3,449 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Overlay Ticket</title>
+  <title>Regal Ticket Generator</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@300;400;600;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
   <style>
     :root {
       color-scheme: only dark;
+      --paper: #f5f0e8;
+      --ink: #111;
+      --accent: #d12b2c;
+      --muted: #666;
+      --stub: #e8dfd3;
+      --shadow: rgba(0, 0, 0, 0.4);
+      font-size: clamp(14px, 2vw, 18px);
     }
-    body {
+
+    * {
+      box-sizing: border-box;
       margin: 0;
+    }
+
+    body {
+      font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+      background: radial-gradient(circle at top, #1d1d1d 0%, #050505 100%);
       min-height: 100vh;
-      background: #000;
       display: flex;
+      flex-direction: column;
+      align-items: center;
       justify-content: center;
-      align-items: flex-start;
-      padding: 24px 0;
+      gap: 2.5rem;
+      padding: 3rem 1rem;
+      color: var(--ink);
     }
-    .ticket-wrap {
+
+    h1 {
+      color: #f9f9f9;
+      letter-spacing: 0.08em;
+      font-weight: 400;
+      text-transform: uppercase;
+      font-size: 1rem;
+    }
+
+    .ticket-stage {
       position: relative;
-      display: inline-block;
+      width: min(90vw, 520px);
+      aspect-ratio: 4 / 9;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      perspective: 2400px;
     }
-    .ticket-wrap img {
-      display: block;
-      height: auto; /* keep natural size, no forced width */
+
+    .ticket-wrapper {
+      transform: rotate(-90deg) rotateX(9deg);
+      transform-origin: center;
+      filter: drop-shadow(0 28px 32px var(--shadow));
     }
-    .overlay {
+
+    .ticket {
+      width: 420px;
+      height: 900px;
+      background: var(--paper);
+      background-image:
+        radial-gradient(circle at 12% 18%, rgba(0, 0, 0, 0.08) 0%, transparent 58%),
+        linear-gradient(180deg, rgba(0,0,0,0.05) 0%, transparent 18%),
+        linear-gradient(90deg, rgba(0,0,0,0.03) 0%, transparent 100%);
+      border-radius: 14px;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      padding: 46px 34px 36px;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .ticket::before,
+    .ticket::after {
+      content: '';
       position: absolute;
-      color: #000;
-      font-family: "Courier New", monospace;
-      font-size: 26px;
-      font-weight: normal;
-      white-space: nowrap;
+      width: 100%;
+      height: 16px;
+      left: 0;
+      background: linear-gradient(90deg, transparent 0 8%, rgba(0, 0, 0, 0.07) 8% 18%, transparent 18% 82%, rgba(0,0,0,0.07) 82% 92%, transparent 92% 100%);
     }
-    #title { font-weight: bold; text-transform: uppercase; }
+
+    .ticket::before { top: 0; }
+    .ticket::after { bottom: 0; }
+
+    .ticket-headline {
+      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
+      text-transform: uppercase;
+      font-size: 3.25rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      margin-bottom: 0.35rem;
+    }
+
+    .ticket-subtitle {
+      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
+      text-transform: uppercase;
+      font-size: 1.4rem;
+      letter-spacing: 0.24em;
+      color: var(--muted);
+      margin-bottom: 1.6rem;
+    }
+
+    .ticket-body {
+      display: grid;
+      grid-template-columns: 1fr 118px;
+      gap: 1.75rem;
+      flex: 1;
+    }
+
+    .ticket-main {
+      display: flex;
+      flex-direction: column;
+      gap: 1.6rem;
+    }
+
+    .show-details {
+      font-family: 'Roboto', sans-serif;
+      display: grid;
+      gap: 0.3rem;
+      font-size: 1.05rem;
+      line-height: 1.35;
+    }
+
+    .show-details strong {
+      font-size: 1.25rem;
+      letter-spacing: 0.08em;
+      font-weight: 600;
+    }
+
+    .ticket-type {
+      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
+      background: var(--accent);
+      color: #fff9f6;
+      padding: 0.5rem 0.9rem;
+      border-radius: 6px;
+      align-self: start;
+      letter-spacing: 0.25em;
+      font-size: 0.95rem;
+    }
+
+    .qr-block {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+      gap: 1.2rem;
+      align-items: center;
+    }
+
+    .qr {
+      width: 140px;
+      height: 140px;
+      background: repeating-linear-gradient(45deg, rgba(0,0,0,0.08) 0, rgba(0,0,0,0.08) 4px, transparent 4px, transparent 8px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .qr canvas {
+      width: 100% !important;
+      height: 100% !important;
+    }
+
+    .qr-notes {
+      font-size: 0.9rem;
+      letter-spacing: 0.05em;
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .qr-notes strong {
+      letter-spacing: 0.12em;
+      font-size: 1rem;
+    }
+
+    .ticket-side {
+      display: grid;
+      align-content: start;
+      justify-items: center;
+      text-transform: uppercase;
+      gap: 1.3rem;
+      position: relative;
+    }
+
+    .ticket-side::before {
+      content: '';
+      position: absolute;
+      inset: -24px 0;
+      border-radius: 0 0 60px 60px;
+      border-left: 2px dashed rgba(0,0,0,0.16);
+    }
+
+    .side-label {
+      font-size: 0.85rem;
+      letter-spacing: 0.4em;
+      color: var(--muted);
+    }
+
+    .side-value {
+      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
+      font-size: 3.6rem;
+      font-weight: 600;
+      letter-spacing: 0.16em;
+    }
+
+    .ticket-footer {
+      margin-top: auto;
+      background: var(--stub);
+      border-radius: 10px;
+      padding: 0.9rem 1.1rem;
+      display: grid;
+      gap: 0.4rem;
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      line-height: 1.45;
+      font-family: 'Roboto Mono', 'Roboto', monospace;
+      color: rgba(0, 0, 0, 0.78);
+    }
+
+    .footer-compact {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8rem 1.6rem;
+    }
+
+    .actions {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    button {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      padding: 0.85rem 1.8rem;
+      background: #f6f6f6;
+      color: #111;
+      font-family: 'Roboto', sans-serif;
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+      box-shadow: 0 12px 20px rgba(0,0,0,0.2);
+    }
+
+    button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 24px rgba(0,0,0,0.26);
+    }
+
+    button:active {
+      transform: translateY(0);
+      box-shadow: 0 10px 18px rgba(0,0,0,0.18);
+    }
+
+    @media (max-width: 680px) {
+      .ticket {
+        width: 360px;
+        height: 780px;
+        padding: 38px 28px 30px;
+      }
+
+      .ticket-body {
+        grid-template-columns: 1fr 100px;
+      }
+
+      .ticket-headline {
+        font-size: 2.8rem;
+      }
+
+      .side-value {
+        font-size: 3rem;
+      }
+
+      .ticket-wrapper {
+        transform: rotate(-90deg) rotateX(7deg) scale(0.9);
+      }
+    }
+
+    @media (max-width: 480px) {
+      .ticket-wrapper {
+        transform: rotate(-90deg) rotateX(5deg) scale(0.82);
+      }
+
+      button {
+        width: 100%;
+      }
+    }
   </style>
 </head>
 <body>
-  <div class="ticket-wrap" id="ticket-wrap">
-    <img src="IMG_3318.jpeg" alt="Ticket" id="ticket-img">
-
-    <!-- merged overlays (kept both sets so nothing is lost) -->
-    <div id="title" class="overlay" data-x="150" data-y="95" data-font="32">MOVIE TITLE</div>
-    <div id="time" class="overlay" data-x="360" data-y="150">TIME</div>
-    <div id="date" class="overlay" data-x="360" data-y="190">DATE</div>
-    <div id="datetime" class="overlay" data-x="360" data-y="160">TIME • DATE</div>
-    <div id="type" class="overlay" data-x="360" data-y="220">Adult</div>
-    <div id="theatre" class="overlay" data-x="560" data-y="150">Theatre: --</div>
-    <div id="seat" class="overlay" data-x="560" data-y="190">Seat: --</div>
+  <h1>Tap your custom URL to refresh the ticket</h1>
+  <div class="ticket-stage">
+    <div class="ticket-wrapper" id="ticket-wrapper">
+      <article class="ticket" id="ticket">
+        <header>
+          <div class="ticket-headline" data-keys="title,movie,film">Saturday Night</div>
+          <div class="ticket-subtitle" data-keys="tagline">Premium Presentation</div>
+        </header>
+        <section class="ticket-body">
+          <div class="ticket-main">
+            <div class="show-details">
+              <strong data-keys="time,showtime">7:15 PM</strong>
+              <span data-keys="date,showdate">Sun, Oct 13 2024</span>
+              <span data-keys="day">Adult Evening</span>
+            </div>
+            <div class="ticket-type" data-keys="type,tickettype,admit">Adult</div>
+            <div class="qr-block">
+              <div class="qr" id="qr">
+                <span>QR</span>
+              </div>
+              <div class="qr-notes">
+                <strong data-keys="venue,theatername,location">Short Pump 14</strong>
+                <span data-keys="price">Adult $14.49 CRED</span>
+                <span data-keys="transaction,trans">Trans #: 443721</span>
+                <span data-keys="printed">10/13/24 • 7:15 PM</span>
+                <span data-keys="agent">07300CIN0 • Heather</span>
+              </div>
+            </div>
+            <footer class="ticket-footer">
+              <div class="footer-compact">
+                <span data-keys="admitline">Admit One</span>
+                <span data-keys="terms">No refunds after showtime</span>
+                <span data-keys="rating">PG-13</span>
+              </div>
+              <span data-keys="footer">Thank you for choosing Regal.</span>
+            </footer>
+          </div>
+          <aside class="ticket-side">
+            <div>
+              <div class="side-label">Theatre</div>
+              <div class="side-value" data-keys="theatre,theater">4</div>
+            </div>
+            <div>
+              <div class="side-label">Seat</div>
+              <div class="side-value" data-keys="seat">I6</div>
+            </div>
+          </aside>
+        </section>
+      </article>
+    </div>
+  </div>
+  <div class="actions">
+    <button type="button" id="save-ticket">Save ticket as image</button>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" integrity="sha256-2n1ytY1/6Yr2vNh+lX6YsJhBKt3vnDnN/SUXOcDS4Fc=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js" integrity="sha256-g9npKfoYZz+uOCoToYtL6vhfVqlhK/SXxPxq8np5xpo=" crossorigin="anonymous"></script>
   <script>
-    function qp(name, def="") {
-      const p = new URLSearchParams(location.search);
-      return p.has(name) ? decodeURIComponent(p.get(name).replace(/\+/g,' ')) : def;
+    function decodeParam(value) {
+      try {
+        return decodeURIComponent(value.replace(/\+/g, ' '));
+      } catch (e) {
+        return value;
+      }
     }
 
-    const ticketImg = document.getElementById("ticket-img");
-    const ticketWrap = document.getElementById("ticket-wrap");
+    function getParams() {
+      return new URLSearchParams(window.location.search);
+    }
 
-    function layoutTicket() {
-      if (!ticketImg.naturalWidth) return;
+    function populateFields() {
+      const params = getParams();
+      const fields = document.querySelectorAll('[data-keys]');
 
-      // merged logic: natural size, capped at screen width
-      const naturalWidth = ticketImg.naturalWidth;
-      const maxWidth = Math.min(naturalWidth, window.innerWidth);
+      fields.forEach((el) => {
+        const keys = el.dataset.keys.split(',').map(k => k.trim().toLowerCase()).filter(Boolean);
+        const key = keys.find(k => params.has(k));
+        if (!key) return;
+        let value = decodeParam(params.get(key));
 
-      ticketWrap.style.width = maxWidth + "px";
-      ticketImg.style.width = maxWidth + "px";
+        if (el.dataset.uppercase === 'true') {
+          value = value.toUpperCase();
+        }
 
-      // position overlays
-      const overlays = document.querySelectorAll(".overlay");
-      overlays.forEach(el => {
-        const x = el.dataset.x || 0;
-        const y = el.dataset.y || 0;
-        const fontSize = el.dataset.font || 26;
+        el.textContent = value;
+      });
 
-        el.style.left = x + "px";
-        el.style.top = y + "px";
-        el.style.fontSize = fontSize + "px";
+      const timeElement = document.querySelector('[data-keys~="time"]');
+      const dateElement = document.querySelector('[data-keys~="date"]');
+      if (params.has('datetime') && timeElement && dateElement) {
+        const combined = decodeParam(params.get('datetime'));
+        const [timePart, datePart] = combined.split(/\s*\|\s*|\s*•\s*|\s*,\s*/);
+        if (timePart) timeElement.textContent = timePart;
+        if (datePart) dateElement.textContent = datePart;
+      }
+
+      const qrValue = params.has('qr')
+        ? decodeParam(params.get('qr'))
+        : [
+            params.get('title') || params.get('movie') || 'Saturday Night',
+            params.get('date') || '2024-10-13',
+            params.get('time') || '7:15 PM',
+            params.get('seat') || 'I6'
+          ].filter(Boolean).join(' | ');
+
+      const qrContainer = document.getElementById('qr');
+      qrContainer.innerHTML = '';
+      QRCode.toCanvas(qrValue, {
+        margin: 1,
+        scale: 6,
+        color: {
+          dark: '#000000',
+          light: '#ffffff'
+        }
+      }, (error, canvas) => {
+        if (error) {
+          qrContainer.textContent = 'QR';
+          return;
+        }
+        canvas.setAttribute('aria-label', qrValue);
+        qrContainer.appendChild(canvas);
       });
     }
 
-    ticketImg.addEventListener("load", layoutTicket);
-    window.addEventListener("resize", layoutTicket);
+    function downloadTicket() {
+      const ticketNode = document.getElementById('ticket-wrapper');
+      document.body.classList.add('exporting');
+      html2canvas(ticketNode, {
+        backgroundColor: null,
+        scale: window.devicePixelRatio > 2 ? 2 : window.devicePixelRatio
+      }).then((canvas) => {
+        const titleEl = document.querySelector('[data-keys^="title"]');
+        const title = titleEl ? titleEl.textContent.trim().replace(/\s+/g, '-') : 'ticket';
+        const link = document.createElement('a');
+        link.download = `${title || 'ticket'}.png`;
+        link.href = canvas.toDataURL('image/png');
+        link.click();
+      }).finally(() => {
+        document.body.classList.remove('exporting');
+      });
+    }
+
+    document.getElementById('save-ticket').addEventListener('click', downloadTicket);
+    window.addEventListener('load', populateFields);
+    window.addEventListener('popstate', populateFields);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the overlay-based layout with a recreated Regal ticket layout that mimics the original artwork
- populate ticket details from URL query parameters and generate a matching QR code
- add an export action that captures the tilted ticket as an image via html2canvas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d53f7fb7188321937c896da7879156