### PR TITLE
Add shareable ticket URL support

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,15 @@
       justify-content: center;
     }
 
+    .share-url {
+      flex-basis: 100%;
+      text-align: center;
+      font-family: 'Roboto Mono', 'Roboto', monospace;
+      font-size: 0.8rem;
+      word-break: break-all;
+      color: #f9f9f9;
+    }
+
     button {
       appearance: none;
       border: none;
@@ -362,9 +371,11 @@
       </article>
     </div>
   </div>
-  <div class="actions">
-    <button type="button" id="save-ticket">Save ticket as image</button>
-  </div>
+    <div class="actions">
+      <button type="button" id="save-ticket">Save ticket as image</button>
+      <button type="button" id="copy-ticket-url">Copy ticket URL</button>
+      <p class="share-url" id="ticket-url-display" aria-live="polite"></p>
+    </div>
 
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" integrity="sha256-2n1ytY1/6Yr2vNh+lX6YsJhBKt3vnDnN/SUXOcDS4Fc=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js" integrity="sha256-g9npKfoYZz+uOCoToYtL6vhfVqlhK/SXxPxq8np5xpo=" crossorigin="anonymous"></script>
@@ -379,6 +390,111 @@
 
     function getParams() {
       return new URLSearchParams(window.location.search);
+    }
+
+    function buildShareableUrl() {
+      const baseUrl = `${window.location.origin}${window.location.pathname}`;
+      const params = new URLSearchParams();
+      const keyValues = new Map();
+
+      document.querySelectorAll('[data-keys]').forEach((el) => {
+        const keys = el.dataset.keys.split(',').map(k => k.trim().toLowerCase()).filter(Boolean);
+        if (!keys.length) return;
+        const text = el.textContent.trim();
+        if (!text) return;
+        keys.forEach((key) => {
+          if (!keyValues.has(key)) {
+            keyValues.set(key, text);
+          }
+        });
+      });
+
+      const prioritizedKeys = [
+        'title',
+        'subtitle',
+        'movie',
+        'feature',
+        'theatre',
+        'theater',
+        'auditorium',
+        'seat',
+        'tickets',
+        'qr'
+      ];
+      prioritizedKeys.forEach((key) => {
+        const value = keyValues.get(key);
+        if (value) {
+          params.set(key, value);
+        }
+      });
+
+      const timeValue = keyValues.get('time');
+      if (timeValue) {
+        params.set('time', timeValue);
+      }
+
+      const dateValue = keyValues.get('date');
+      if (dateValue) {
+        params.set('date', dateValue);
+      }
+
+      const datetimeValue = keyValues.get('datetime');
+      if (datetimeValue) {
+        params.set('datetime', datetimeValue);
+      } else if (timeValue && dateValue) {
+        params.set('datetime', `${timeValue} | ${dateValue}`);
+      }
+
+      const query = params.toString();
+      return query ? `${baseUrl}?${query}` : baseUrl;
+    }
+
+    function updateShareUrlDisplay(forcedUrl) {
+      const display = document.getElementById('ticket-url-display');
+      if (!display) return;
+      const url = forcedUrl || buildShareableUrl();
+      display.textContent = url;
+    }
+
+    function signalCopySuccess(url) {
+      updateShareUrlDisplay(url);
+      const copyButton = document.getElementById('copy-ticket-url');
+      if (!copyButton) return;
+      const originalText = copyButton.textContent;
+      copyButton.textContent = 'Link copied!';
+      setTimeout(() => {
+        copyButton.textContent = originalText;
+      }, 2000);
+    }
+
+    function fallbackCopy(url) {
+      const textarea = document.createElement('textarea');
+      textarea.value = url;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+      } catch (err) {
+        console.error('Copy failed', err);
+      }
+      document.body.removeChild(textarea);
+      signalCopySuccess(url);
+    }
+
+    function copyTicketUrl() {
+      const url = buildShareableUrl();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(() => {
+          signalCopySuccess(url);
+        }).catch(() => {
+          fallbackCopy(url);
+        });
+      } else {
+        fallbackCopy(url);
+      }
     }
 
     function populateFields() {
@@ -433,6 +549,8 @@
         canvas.setAttribute('aria-label', qrValue);
         qrContainer.appendChild(canvas);
       });
+
+      updateShareUrlDisplay();
     }
 
     function downloadTicket() {
@@ -454,6 +572,10 @@
     }
 
     document.getElementById('save-ticket').addEventListener('click', downloadTicket);
+    const copyButton = document.getElementById('copy-ticket-url');
+    if (copyButton) {
+      copyButton.addEventListener('click', copyTicketUrl);
+    }
     window.addEventListener('load', populateFields);
     window.addEventListener('popstate', populateFields);
   </script>


### PR DESCRIPTION
## Summary
- add a copyable ticket URL control and display so the generated link is visible
- build a shareable query string from the current ticket data and keep the display updated
- support copying the link via the Clipboard API with a fallback when permissions are unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5470543ec83219d61004ef3e785cf