### PR TITLE
Rework ticket layout with simplified matrix design

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,610 +3,329 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Regal Ticket Generator</title>
+  <title>Matrix Ticket Generator</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@300;400;600;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
   <style>
     :root {
-      color-scheme: only dark;
-      --paper: #f5f0e8;
-      --ink: #111;
-      --accent: #d12b2c;
-      --muted: #666;
-      --stub: #e8dfd3;
-      --shadow: rgba(0, 0, 0, 0.4);
-      font-size: clamp(14px, 2vw, 18px);
+      --ink: #050505;
+      --paper: #ffffff;
+      --shadow: rgba(0, 0, 0, 0.08);
     }
 
-    * {
+    *, *::before, *::after {
       box-sizing: border-box;
+    }
+
+    html, body {
       margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: var(--paper);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'VT323', monospace;
+      color: var(--ink);
     }
 
     body {
-      font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
-      background: #000;
-      min-height: 100vh;
+      padding: clamp(12px, 4vw, 40px);
+    }
+
+    .page {
       display: flex;
+      flex-direction: column;
       align-items: center;
-      justify-content: center;
-      margin: 0;
-      padding: 0;
-    }
-
-    .ticket-image {
-      display: inline-flex;
-      border-radius: 12px;
-      overflow: hidden;
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
-      position: relative;
-    }
-
-    .ticket-overlay {
-      position: absolute;
-      inset: 0;
-      display: block;
-      pointer-events: none;
-      color: #101010;
-      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
-      text-transform: uppercase;
-      transform-origin: center center;
-    }
-
-    .ticket-overlay span {
-      position: absolute;
-      white-space: nowrap;
-      letter-spacing: 0.14em;
-      font-weight: 600;
-      font-size: 1.35rem;
-    }
-
-    .ticket-overlay .overlay-headline {
-      top: 9.5%;
-      left: 50%;
-      transform: translateX(-50%);
-      font-size: 2.9rem;
-      letter-spacing: 0.12em;
-    }
-
-    .ticket-overlay .overlay-subtitle {
-      top: 16.5%;
-      left: 50%;
-      transform: translateX(-50%);
-      font-size: 1.15rem;
-      letter-spacing: 0.28em;
-    }
-
-    .ticket-overlay .overlay-showtime {
-      top: 34%;
-      left: 17%;
-    }
-
-    .ticket-overlay .overlay-seat {
-      top: 42%;
-      left: 17%;
-    }
-
-    .ticket-overlay .overlay-admit {
-      top: 50.5%;
-      left: 17%;
-      font-size: 1.1rem;
-    }
-
-    .ticket-overlay .overlay-type {
-      top: 27%;
-      right: 13%;
-      font-size: 1.05rem;
-      background: rgba(209, 43, 44, 0.88);
-      color: #fff9f6;
-      padding: 0.35rem 0.7rem;
-      border-radius: 6px;
-      letter-spacing: 0.32em;
-    }
-
-    .ticket-overlay .overlay-side {
-      bottom: 12%;
-      right: 6%;
-      font-size: 2.9rem;
-      letter-spacing: 0.18em;
-    }
-
-    .ticket-overlay .overlay-footer {
-      bottom: 6.5%;
-      left: 50%;
-      transform: translateX(-50%);
-      font-family: 'Roboto Mono', 'Roboto', monospace;
-      font-size: 0.82rem;
-      letter-spacing: 0.1em;
-      text-transform: none;
-      white-space: normal;
-      width: 70%;
-      text-align: center;
-    }
-
-    .ticket-image img {
-      display: block;
-      width: auto;
-      height: auto;
-      max-width: 90vw;
-      max-height: 90vh;
-    }
-
-    h1 {
-      color: #f9f9f9;
-      letter-spacing: 0.08em;
-      font-weight: 400;
-      text-transform: uppercase;
-      font-size: 1rem;
-    }
-
-    .ticket-stage {
-      position: relative;
-      width: min(90vw, 520px);
-      aspect-ratio: 4 / 9;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      perspective: 2400px;
-    }
-
-    .ticket-wrapper {
-      transform: rotate(-90deg) rotateX(9deg);
-      transform-origin: center;
-      filter: drop-shadow(0 28px 32px var(--shadow));
+      gap: 20px;
     }
 
     .ticket {
-      width: 420px;
-      height: 900px;
+      width: min(1000px, 94vw);
+      max-width: 1000px;
+      min-height: clamp(360px, 40vw, 450px);
       background: var(--paper);
-      background-image:
-        radial-gradient(circle at 12% 18%, rgba(0, 0, 0, 0.08) 0%, transparent 58%),
-        linear-gradient(180deg, rgba(0,0,0,0.05) 0%, transparent 18%),
-        linear-gradient(90deg, rgba(0,0,0,0.03) 0%, transparent 100%);
-      border-radius: 14px;
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      padding: clamp(24px, 4vw, 40px);
+      box-sizing: border-box;
+      box-shadow: 0 22px 40px rgba(0, 0, 0, 0.12);
+      border-radius: 20px;
       border: 1px solid rgba(0, 0, 0, 0.08);
-      padding: 46px 34px 36px;
+      gap: clamp(24px, 4vw, 40px);
+    }
+
+    .left {
+      flex: 0 0 clamp(320px, 60%, 600px);
       display: flex;
       flex-direction: column;
-      position: relative;
+    }
+
+    .title {
+      font-weight: 700;
+      font-size: clamp(36px, 6vw, 64px);
+      margin-bottom: clamp(16px, 3vw, 30px);
+      white-space: nowrap;
       overflow: hidden;
-    }
-
-    .ticket::before,
-    .ticket::after {
-      content: '';
-      position: absolute;
-      width: 100%;
-      height: 16px;
-      left: 0;
-      background: linear-gradient(90deg, transparent 0 8%, rgba(0, 0, 0, 0.07) 8% 18%, transparent 18% 82%, rgba(0,0,0,0.07) 82% 92%, transparent 92% 100%);
-    }
-
-    .ticket::before { top: 0; }
-    .ticket::after { bottom: 0; }
-
-    .ticket-headline {
-      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
+      text-overflow: ellipsis;
       text-transform: uppercase;
-      font-size: 3.25rem;
-      font-weight: 600;
       letter-spacing: 0.08em;
-      margin-bottom: 0.35rem;
     }
 
-    .ticket-subtitle {
-      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
+    .meta {
+      font-size: clamp(18px, 2.6vw, 28px);
+      line-height: 1.6;
+      margin-bottom: clamp(22px, 4vw, 40px);
       text-transform: uppercase;
-      font-size: 1.4rem;
-      letter-spacing: 0.24em;
-      color: var(--muted);
-      margin-bottom: 1.6rem;
-    }
-
-    .ticket-body {
-      display: grid;
-      grid-template-columns: 1fr 118px;
-      gap: 1.75rem;
-      flex: 1;
-    }
-
-    .ticket-main {
-      display: flex;
-      flex-direction: column;
-      gap: 1.6rem;
-    }
-
-    .show-details {
-      font-family: 'Roboto', sans-serif;
-      display: grid;
-      gap: 0.3rem;
-      font-size: 1.05rem;
-      line-height: 1.35;
-    }
-
-    .show-details strong {
-      font-size: 1.25rem;
       letter-spacing: 0.08em;
-      font-weight: 600;
-    }
-
-    .ticket-type {
-      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
-      background: var(--accent);
-      color: #fff9f6;
-      padding: 0.5rem 0.9rem;
-      border-radius: 6px;
-      align-self: start;
-      letter-spacing: 0.25em;
-      font-size: 0.95rem;
-    }
-
-    .qr-block {
-      display: grid;
-      grid-template-columns: 140px 1fr;
-      gap: 1.2rem;
-      align-items: center;
     }
 
     .qr {
-      width: 140px;
-      height: 140px;
-      background: repeating-linear-gradient(45deg, rgba(0,0,0,0.08) 0, rgba(0,0,0,0.08) 4px, transparent 4px, transparent 8px);
+      width: clamp(120px, 16vw, 160px);
+      height: clamp(120px, 16vw, 160px);
+      border: 2px solid rgba(0, 0, 0, 0.12);
+      border-radius: 12px;
+      padding: 8px;
+      box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+      background: #fff;
+      object-fit: contain;
+    }
+
+    .right {
+      flex: 0 0 clamp(220px, 32%, 300px);
+      text-align: left;
       display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 8px;
-      overflow: hidden;
+      flex-direction: column;
+      justify-content: flex-start;
     }
 
-    .qr canvas {
-      width: 100% !important;
-      height: 100% !important;
-    }
-
-    .qr-notes {
-      font-size: 0.9rem;
-      letter-spacing: 0.05em;
-      display: grid;
-      gap: 0.35rem;
-    }
-
-    .qr-notes strong {
-      letter-spacing: 0.12em;
-      font-size: 1rem;
-    }
-
-    .ticket-side {
-      display: grid;
-      align-content: start;
-      justify-items: center;
+    .label {
+      font-size: clamp(18px, 2.4vw, 28px);
+      margin-top: clamp(8px, 1.4vw, 10px);
       text-transform: uppercase;
-      gap: 1.3rem;
-      position: relative;
+      letter-spacing: 0.1em;
     }
 
-    .ticket-side::before {
-      content: '';
-      position: absolute;
-      inset: -24px 0;
-      border-radius: 0 0 60px 60px;
-      border-left: 2px dashed rgba(0,0,0,0.16);
+    .big {
+      font-size: clamp(36px, 6vw, 64px);
+      font-weight: 700;
+      margin-top: 4px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
     }
 
-    .side-label {
-      font-size: 0.85rem;
-      letter-spacing: 0.4em;
-      color: var(--muted);
+    .txbox {
+      margin-top: clamp(16px, 2.6vw, 20px);
+      font-size: clamp(14px, 1.8vw, 20px);
+      line-height: 1.4;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
-    .side-value {
-      font-family: 'Barlow Condensed', 'Roboto', sans-serif;
-      font-size: 3.6rem;
-      font-weight: 600;
-      letter-spacing: 0.16em;
-    }
-
-    .ticket-footer {
-      margin-top: auto;
-      background: var(--stub);
-      border-radius: 10px;
-      padding: 0.9rem 1.1rem;
-      display: grid;
-      gap: 0.4rem;
-      font-size: 0.78rem;
-      letter-spacing: 0.08em;
-      line-height: 1.45;
-      font-family: 'Roboto Mono', 'Roboto', monospace;
-      color: rgba(0, 0, 0, 0.78);
-    }
-
-    .footer-compact {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.8rem 1.6rem;
+    .txbox strong {
+      font-weight: 700;
     }
 
     .actions {
       display: flex;
-      gap: 1rem;
-      flex-wrap: wrap;
-      justify-content: center;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
     }
 
-    .share-url {
-      flex-basis: 100%;
-      text-align: center;
-      font-family: 'Roboto Mono', 'Roboto', monospace;
-      font-size: 0.8rem;
-      word-break: break-all;
-      color: #f9f9f9;
-    }
-
-    button {
+    .save-button {
       appearance: none;
       border: none;
+      background: var(--ink);
+      color: #fff;
+      padding: 0.75rem 1.8rem;
       border-radius: 999px;
-      padding: 0.85rem 1.8rem;
-      background: #f6f6f6;
-      color: #111;
-      font-family: 'Roboto', sans-serif;
-      font-size: 0.95rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
       cursor: pointer;
-      transition: transform 120ms ease, box-shadow 120ms ease;
-      box-shadow: 0 12px 20px rgba(0,0,0,0.2);
+      font-family: inherit;
+      font-size: 1rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 26px rgba(0, 0, 0, 0.25);
     }
 
-    button:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 24px rgba(0,0,0,0.26);
+    .save-button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.28);
     }
 
-    button:active {
-      transform: translateY(0);
-      box-shadow: 0 10px 18px rgba(0,0,0,0.18);
+    .save-button:disabled {
+      opacity: 0.6;
+      cursor: progress;
+      transform: none;
+      box-shadow: none;
     }
 
-    @media (max-width: 680px) {
+    .save-hint {
+      color: rgba(0, 0, 0, 0.68);
+      font-size: 0.95rem;
+      text-align: center;
+      max-width: 440px;
+      line-height: 1.5;
+      letter-spacing: 0.05em;
+    }
+
+    @media (max-width: 720px) {
       .ticket {
-        width: 360px;
-        height: 780px;
-        padding: 38px 28px 30px;
+        flex-direction: column;
+        align-items: stretch;
+        text-align: left;
       }
 
-      .ticket-body {
-        grid-template-columns: 1fr 100px;
+      .left,
+      .right {
+        flex: 1 1 auto;
       }
 
-      .ticket-headline {
-        font-size: 2.8rem;
-      }
-
-      .side-value {
-        font-size: 3rem;
-      }
-
-      .ticket-wrapper {
-        transform: rotate(-90deg) rotateX(7deg) scale(0.9);
-      }
-    }
-
-    @media (max-width: 480px) {
-      .ticket-wrapper {
-        transform: rotate(-90deg) rotateX(5deg) scale(0.82);
-      }
-
-      button {
-        width: 100%;
+      .right {
+        margin-left: 0;
       }
     }
   </style>
 </head>
 <body>
-  <a class="ticket-image" href="IMG_3318.jpeg">
-    <img src="IMG_3318.jpeg" alt="Printed Regal ticket for Saturday Night with QR code">
-    <span class="ticket-overlay">
-      <span class="overlay-headline" data-field="headline" data-default="Saturday Night"></span>
-      <span class="overlay-subtitle" data-field="subtitle" data-default="Premiere"></span>
-      <span class="overlay-showtime" data-field="showtime" data-default="SAT • 7:30 PM"></span>
-      <span class="overlay-seat" data-field="seat" data-default="SEAT H12"></span>
-      <span class="overlay-admit" data-field="admit" data-default="ADMIT ONE"></span>
-      <span class="overlay-type" data-field="type" data-default="VIP"></span>
-      <span class="overlay-side" data-field="side" data-default="H12"></span>
-      <span class="overlay-footer" data-field="notes" data-default="Scan the QR code at entry • Non-transferable"></span>
-    </span>
-  </a>
+  <div class="page">
+    <div class="ticket" id="ticket">
+      <div class="left">
+        <div class="title" data-ticket-field="title">Movie Title</div>
+        <div class="meta">
+          <span data-ticket-field="datetime">7:00pm Wed 11/20/24</span><br>
+          <span data-ticket-field="admission">Adult</span>
+        </div>
+        <img class="qr" id="qrImage" alt="Ticket QR code" src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&amp;data=Movie%20Title">
+      </div>
+      <div class="right">
+        <div class="label">Theatre:</div>
+        <div class="big" data-ticket-field="theatre">7</div>
+        <div class="label">Seat:</div>
+        <div class="big" data-ticket-field="seat">D-8</div>
+        <div class="txbox">
+          <div><strong data-ticket-field="location">Short Pump 14</strong></div>
+          <div data-ticket-field="price">Adult $23.99 CRED</div>
+          <div data-ticket-field="transaction">Trans #: 0730CAF30</div>
+          <div data-ticket-field="timestamp">11/10/24 7:57pm</div>
+          <div data-ticket-field="order">07300CM10-Heather</div>
+        </div>
+      </div>
+    </div>
+    <div class="actions">
+      <button class="save-button" id="saveButton" type="button">Save Ticket Photo</button>
+      <p class="save-hint">Tip: Tap “Save Ticket Photo”, then long-press the image on your iPhone to add it to Photos.</p>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" integrity="sha384-Jv4jArtyTc95xJMu38xpv8uKUa95syEHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiM" crossorigin="anonymous"></script>
   <script>
     (function () {
+      const defaults = {
+        'title': 'Movie Title',
+        'datetime': '7:00pm Wed 11/20/24',
+        'admission': 'Adult',
+        'theatre': '7',
+        'seat': 'D-8',
+        'location': 'Short Pump 14',
+        'price': 'Adult $23.99 CRED',
+        'transaction': 'Trans #: 0730CAF30',
+        'timestamp': '11/10/24 7:57pm',
+        'order': '07300CM10-Heather',
+        'qr': 'Movie Title'
+      };
+
       const params = new URLSearchParams(window.location.search);
-      const overlay = document.querySelectorAll('[data-field]');
-      overlay.forEach((node) => {
-        const key = node.dataset.field;
-        const rawValue = params.get(key);
-        const value = rawValue ? rawValue : node.dataset.default || '';
-        node.textContent = value;
+      const data = { ...defaults };
+
+      params.forEach((value, key) => {
+        const normalized = key.trim().toLowerCase();
+        if (normalized in data) {
+          data[normalized] = value;
+        }
       });
 
-      const ticketLink = document.querySelector('.ticket-image');
-      if (!ticketLink) {
-        return;
+      document.querySelectorAll('[data-ticket-field]').forEach((node) => {
+        const field = node.getAttribute('data-ticket-field');
+        if (field && field in data) {
+          node.textContent = data[field];
+        }
+      });
+
+      const titleNode = document.querySelector('[data-ticket-field="title"]');
+      if (titleNode) {
+        const toUpper = (data.title || defaults.title).toUpperCase();
+        titleNode.textContent = toUpper;
+        let size = 64;
+        const min = 28;
+        titleNode.style.fontSize = size + 'px';
+        while (titleNode.scrollWidth > titleNode.clientWidth && size > min) {
+          size -= 1;
+          titleNode.style.fontSize = size + 'px';
+        }
       }
 
-      const ticketImage = ticketLink.querySelector('img');
-      const ticketOverlay = ticketLink.querySelector('.ticket-overlay');
-
-      if (!ticketImage || !ticketOverlay || ticketImage.dataset.composited === 'true') {
-        return;
+      const qrImage = document.getElementById('qrImage');
+      if (qrImage) {
+        const qrValue = encodeURIComponent(data.qr || defaults.qr);
+        qrImage.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${qrValue}`;
       }
 
-      const imageReady = ticketImage.complete
-        ? Promise.resolve()
-        : new Promise((resolve) => ticketImage.addEventListener('load', resolve, { once: true }));
-      const fontsReady = document.fonts ? document.fonts.ready : Promise.resolve();
+      const saveButton = document.getElementById('saveButton');
+      const ticketNode = document.getElementById('ticket');
 
-      Promise.all([imageReady, fontsReady]).then(() => {
-        if (!ticketImage.naturalWidth || !ticketImage.naturalHeight || ticketImage.dataset.composited === 'true') {
+      async function saveTicket() {
+        if (!ticketNode) {
           return;
         }
 
-        const orientation = detectOrientation(ticketImage);
-        applyOverlayRotation(ticketOverlay, orientation);
+        saveButton.disabled = true;
+        saveButton.textContent = 'Rendering…';
 
-        requestAnimationFrame(() => {
-          mergeOverlay(ticketLink, ticketImage, ticketOverlay).catch((error) => {
-            console.error('Unable to merge ticket overlay', error);
+        const scale = window.devicePixelRatio > 1 ? window.devicePixelRatio : 2;
+        let renderedCanvas = null;
+
+        try {
+          renderedCanvas = await html2canvas(ticketNode, {
+            backgroundColor: '#ffffff',
+            scale,
+            useCORS: true,
+            imageTimeout: 0,
+            onclone: (doc) => {
+              const clonedTicket = doc.getElementById('ticket');
+              if (clonedTicket) {
+                clonedTicket.style.boxShadow = 'none';
+              }
+            }
           });
-        });
-      });
 
-      function applyOverlayRotation(overlayNode, orientation) {
-        if (!overlayNode) {
-          return;
-        }
+          const dataUrl = renderedCanvas.toDataURL('image/png');
+          const link = document.createElement('a');
+          link.href = dataUrl;
+          link.download = 'movie-ticket.png';
 
-        if (orientation === 'landscape-clockwise') {
-          overlayNode.style.transform = 'rotate(90deg)';
-        } else if (orientation === 'landscape-counterclockwise') {
-          overlayNode.style.transform = 'rotate(-90deg)';
-        } else {
-          overlayNode.style.transform = 'none';
-        }
-      }
-
-      function detectOrientation(imageNode) {
-        if (imageNode.naturalWidth <= imageNode.naturalHeight) {
-          return 'portrait';
-        }
-
-        const tempCanvas = document.createElement('canvas');
-        tempCanvas.width = imageNode.naturalWidth;
-        tempCanvas.height = imageNode.naturalHeight;
-        const ctx = tempCanvas.getContext('2d');
-
-        if (!ctx) {
-          return 'landscape-clockwise';
-        }
-
-        ctx.drawImage(imageNode, 0, 0);
-
-        const measureEdge = (x, y, width, height) => {
-          const data = ctx.getImageData(x, y, width, height).data;
-          let score = 0;
-          for (let i = 0; i < data.length; i += 4) {
-            const r = data[i];
-            const g = data[i + 1];
-            const b = data[i + 2];
-            score += Math.max(0, r - (g + b) / 2);
+          if (typeof link.download === 'string') {
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          } else {
+            window.open(dataUrl, '_blank');
           }
-          return score / Math.max(1, (width * height));
-        };
-
-        const edgeHeight = Math.max(1, Math.round(tempCanvas.height * 0.12));
-        const topScore = measureEdge(0, 0, tempCanvas.width, edgeHeight);
-        const bottomScore = measureEdge(0, tempCanvas.height - edgeHeight, tempCanvas.width, edgeHeight);
-
-        if (bottomScore > topScore) {
-          return 'landscape-clockwise';
+        } catch (error) {
+          console.error('Unable to generate ticket image', error);
+          if (renderedCanvas) {
+            window.open(renderedCanvas.toDataURL('image/png'), '_blank');
+          }
+        } finally {
+          saveButton.disabled = false;
+          saveButton.textContent = 'Save Ticket Photo';
         }
-
-        if (topScore > bottomScore) {
-          return 'landscape-counterclockwise';
-        }
-
-        const edgeWidth = Math.max(1, Math.round(tempCanvas.width * 0.12));
-        const rightScore = measureEdge(tempCanvas.width - edgeWidth, 0, edgeWidth, tempCanvas.height);
-        const leftScore = measureEdge(0, 0, edgeWidth, tempCanvas.height);
-
-        return rightScore >= leftScore ? 'landscape-clockwise' : 'landscape-counterclockwise';
       }
 
-      function mergeOverlay(linkNode, imageNode, overlayNode) {
-        return new Promise((resolve, reject) => {
-          const rect = imageNode.getBoundingClientRect();
-          const displayWidth = Math.round(rect.width);
-          const displayHeight = Math.round(rect.height);
-
-          if (!displayWidth || !displayHeight) {
-            resolve();
-            return;
-          }
-
-          const ratio = window.devicePixelRatio || 1;
-          const canvas = document.createElement('canvas');
-          canvas.width = Math.round(displayWidth * ratio);
-          canvas.height = Math.round(displayHeight * ratio);
-          const ctx = canvas.getContext('2d');
-
-          if (!ctx) {
-            resolve();
-            return;
-          }
-
-          ctx.scale(ratio, ratio);
-          ctx.drawImage(imageNode, 0, 0, displayWidth, displayHeight);
-
-          const overlayDataUrl = buildOverlayDataUrl(overlayNode, displayWidth, displayHeight);
-          loadImage(overlayDataUrl)
-            .then((overlayImage) => {
-              ctx.drawImage(overlayImage, 0, 0, displayWidth, displayHeight);
-              const mergedUrl = canvas.toDataURL('image/png');
-              imageNode.dataset.composited = 'true';
-              imageNode.src = mergedUrl;
-              linkNode.href = mergedUrl;
-              linkNode.setAttribute('download', 'ticket.png');
-              overlayNode.style.display = 'none';
-              resolve();
-            })
-            .catch(reject);
-        });
-      }
-
-      function buildOverlayDataUrl(overlayNode, width, height) {
-        const wrapper = document.createElement('div');
-        wrapper.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
-        wrapper.style.position = 'relative';
-        wrapper.style.width = `${width}px`;
-        wrapper.style.height = `${height}px`;
-
-        const clone = overlayNode.cloneNode(true);
-        clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
-        wrapper.appendChild(clone);
-        applyInlineStyles(overlayNode, clone);
-
-        const serializer = new XMLSerializer();
-        const html = serializer.serializeToString(wrapper);
-        const styleBlock = "<style>@import url('https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@300;400;600;700&family=Roboto:wght@300;400;500;700&display=swap');</style>";
-        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">${styleBlock}<foreignObject width="100%" height="100%">${html}</foreignObject></svg>`;
-        return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-      }
-
-      function applyInlineStyles(sourceNode, targetNode) {
-        const sourceElements = [sourceNode, ...sourceNode.querySelectorAll('*')];
-        const targetElements = [targetNode, ...targetNode.querySelectorAll('*')];
-
-        sourceElements.forEach((element, index) => {
-          const computed = window.getComputedStyle(element);
-          let cssText = '';
-          for (let i = 0; i < computed.length; i++) {
-            const property = computed[i];
-            const value = computed.getPropertyValue(property);
-            cssText += `${property}:${value};`;
-          }
-          targetElements[index].setAttribute('style', cssText);
-        });
-      }
-
-      function loadImage(src) {
-        return new Promise((resolve, reject) => {
-          const imgNode = new Image();
-          imgNode.onload = () => resolve(imgNode);
-          imgNode.onerror = reject;
-          imgNode.src = src;
-        });
-      }
+      saveButton.addEventListener('click', saveTicket);
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the previous perforated ticket composition with a two-column layout modeled on the provided template while keeping the VT323 matrix type
- simplify the dynamic data bindings to match the new markup and add title auto-fit logic that enforces uppercase display
- retain the html2canvas export flow with white-background rendering and updated hinting for saving to iPhone

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d569ac1a248321a6d842ad7e746534